### PR TITLE
Make python handle line splitting

### DIFF
--- a/available.py
+++ b/available.py
@@ -11,3 +11,13 @@ def get_free_gpu_ids(max_util=0.1, max_mem_util=0.5):
         if float(gpu_utils[i]) < max_util and float(mem_utils[i]) < max_mem_util:
             free_gpus.append(i)
     return free_gpus
+
+def get_gpus_sorted(sort_key="memory.free", reverse=True, get_vals=False):
+    free_gpus = []
+
+    gpu_vals = [float(str) for str in query(sort_key)]
+    free_gpus = [i for i, val in sorted(enumerate(gpu_vals), key=lambda x: x[1])]
+    if get_vals:
+        return (free_gpus, sorted(gpu_vals))
+    else:
+        return free_gpus

--- a/nvsmpy.py
+++ b/nvsmpy.py
@@ -13,22 +13,22 @@ def _parse_valid_queries() -> typing.Dict:
 
     output, _ = proc.communicate()
     dec_output = output.decode("utf-8")
-    sections = dec_output.split("\r\n\r\n")
-    
+    sections = dec_output.splitlines()
+
     valid_queries = {}
+    query_found = False
     for section in sections:
         if len(section) != 0:
-            if section[0][0] in quote_chars:
-                subsections = section.split("\r\n")
-                if subsections[0][-1] in quote_chars:
-                    for qc in quote_chars:  # remove all quote chars from output
-                        subsections[0] = subsections[0].replace(qc, "")
-                    query = subsections[0].split(" or ")
-                    description = subsections[1]
-
-                    for synonym in query:
-                        valid_queries[synonym] = description
-    
+            if section[0] in quote_chars and section[-1] in quote_chars:
+                for qc in quote_chars:  # remove all quote chars from output
+                    section = section.replace(qc, "")
+                query = section.split(" or ")
+                # This flags that the next nonzero-length section will contain the description of the current query
+                query_found = True
+            elif query_found:
+                for synonym in query:
+                    valid_queries[synonym] = section
+                query_found = False
     return valid_queries
 
 


### PR DESCRIPTION
On my machine (Ubuntu 18, nvidia-smi 410.79), the function _parse_valid_queries() failed because line endings were set with "\n\n" instead of "\r\n". 
I changed the code to use python's own string.splitlines() function, which should be less prone to such errors. 
Sadly, I am not able to test on other versions of nvidia-smi, or different OSes. 